### PR TITLE
Use integers for iteration

### DIFF
--- a/pisum/iter.jl
+++ b/pisum/iter.jl
@@ -1,4 +1,4 @@
 #!/usr/bin/env julia
 
-function f(n) x = 0.; for ii = 0.:n-1.; x = 0.5*x + mod(ii,10.); if x>1e100; break; end; end; end
-@time f(1e6)
+function f(n) x = 0.; for ii = 0:n-1; x = 0.5*x + mod(ii,10); if x>1e100; break; end; end; return x; end
+@time f(10^6)


### PR DESCRIPTION
On my machine this yields a 5x speedup. Note that without the `return x` the compiler will optimize the entire function body away.